### PR TITLE
feat: The host will now reject concurrent requests above a threshold.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "crates/fastembed-rs"]
-	path = crates/fastembed-rs
-	url = git@github.com:denwong47/fastembed-rs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,12 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,12 +302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,33 +327,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
 
 [[package]]
 name = "clap"
@@ -464,42 +425,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -648,7 +573,7 @@ checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "embedder"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "embedder-err",
  "embedder-external",
@@ -738,10 +663,11 @@ dependencies = [
 
 [[package]]
 name = "fastembed"
-version = "3.14.1"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32ee8c9f4219e3700aa9e201028e1c8206072794cae0b8323c1463f7b93466"
 dependencies = [
  "anyhow",
- "criterion",
  "hf-hub",
  "image",
  "ndarray",
@@ -924,12 +850,6 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
-
-[[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hf-hub"
@@ -1128,30 +1048,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi 0.4.0",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1202,15 +1102,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
-name = "js-sys"
-version = "0.3.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,16 +1128,6 @@ dependencies = [
  "arbitrary",
  "cc",
  "once_cell",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1377,7 +1258,7 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1423,14 +1304,16 @@ dependencies = [
 
 [[package]]
 name = "ndarray"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "073c7c76f7b90654996f08db92290e9f300d11de0634493d6f1c4fd11d8a1583"
+checksum = "087ee1ca8a7c22830c2bba4a96ed8e72ce0968ae944349324d52522f66aa3944"
 dependencies = [
  "matrixmultiply",
  "num-complex",
  "num-integer",
  "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
  "rawpointer",
  "serde",
 ]
@@ -1560,12 +1443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
 name = "openssl"
 version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,24 +1494,20 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ort"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d83095ae3c1258738d70ae7a06195c94d966a8e546f0d3609dc90885fb61f5"
+checksum = "52afb44b6b0cffa9bf45e4d37e5a4935b0334a51570658e279e9e3e6cf324aa5"
 dependencies = [
- "js-sys",
- "libloading",
  "ndarray",
  "ort-sys",
- "thiserror",
  "tracing",
- "web-sys",
 ]
 
 [[package]]
 name = "ort-sys"
-version = "2.0.0-rc.4"
+version = "2.0.0-rc.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2f6427193c808010b126bef45ebd33f8dee43770223a1200f84d3734d6c656"
+checksum = "c41d7757331aef2d04b9cb09b45583a59217628beaf91895b7e76187b6e8c088"
 dependencies = [
  "flate2",
  "pkg-config",
@@ -1694,34 +1567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "png"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +1584,15 @@ name = "portable-atomic"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "ppv-lite86"
@@ -2078,15 +1932,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,16 +2241,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2548,19 +2383,7 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.75",
 ]
 
 [[package]]
@@ -2723,16 +2546,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2794,16 +2607,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
-name = "web-sys"
-version = "0.3.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "webpki-roots"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2833,15 +2636,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ authors = [
 ]
 name = "embedder"
 description = "API to embed documents into various formats."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 exclude = ["crates/fastembed-rs/**", "models/**"]
@@ -27,6 +27,7 @@ tokio = { version = "1.39.2", features = ["sync", "macros", "rt-multi-thread", "
 
 [workspace]
 members = [
+    "",
     "crates/embedder-err",
     "crates/embedder-external",
     "crates/embedder-lib",

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The project is split into three parts:
   > This library will embed the whole model into the binary, in order to simplify deployment. This lengthens the build time of the library, but makes the resulting binary more portable.
 
 - `make convert_model MODEL=...`: A Make target that converts a PyTorch model into an ONNX model. This is required for the `embedder-lib` to work. This utilizes `torch` and `optimium` within a Docker container, which is not required for the final deployment.
-- `make host`: A Make target that hosts the API on `localhost:3000`. This is a simple API that accepts a `POST` request with a JSON body containing a list of strings, and returns a JSON body containing a list of embeddings. This can be followed by `make export_host` to export the built image into a Docker image for deployment.
+- `make host`: A Make target that hosts the API on `localhost:3456`. This is a simple API that accepts a `POST` request with a JSON body containing a list of strings, and returns a JSON body containing a list of embeddings. This can be followed by `make export_host` to export the built image into a Docker image for deployment.
 
 ## How to run
 
@@ -65,7 +65,7 @@ An example workflow will be:
     - `zero-shot-image-classification`
     - `text-generation`
   - Check your model on the HuggingFace model hub to see if it supports the task you are trying to convert.
-- Run `make host` to host the API on `localhost:3000`.
+- Run `make host` to host the API on `localhost:3456`.
 - Test the endpoint using your desired HTTP client, such as `requests` in Python:
 
   ```python
@@ -76,7 +76,7 @@ An example workflow will be:
   ...     "This is another test sentence.",
   ...     "Foo Bar",
   ... ]
-  >>> response = requests.post("http://localhost:3000/embed?output=array", json={ "model": "sentence-transformers/all-MiniLM-L6-v2", "documents": docs })
+  >>> response = requests.post("http://localhost:3456/embed?output=array", json={ "model": "sentence-transformers/all-MiniLM-L6-v2", "documents": docs })
   >>> response.json()
   {'duration': 0.5497052669525146,
    'embeddings': {'data': [0.08429647982120514,

--- a/crates/embedder-err/src/api.rs
+++ b/crates/embedder-err/src/api.rs
@@ -71,6 +71,9 @@ pub enum EmbedderAPIError {
     #[error("Error during concurrency provision: {0}")]
     ConcurrencyError(String),
 
+    #[error("Too many concurrent requests: {0}")]
+    TooManyConcurrentRequests(usize),
+
     // This is just a demo of how to export `errors`. It is unlikely that we can check
     // each input and return a list of errors like this.
     #[error("Cannot embed some of the inputs.")]
@@ -83,7 +86,14 @@ pub enum EmbedderAPIError {
 impl EmbedderAPIError {
     /// Get the status code for the error.
     pub fn status_code(&self) -> StatusCode {
-        StatusCode::INTERNAL_SERVER_ERROR
+        match self {
+            Self::ArgsError(_) => StatusCode::BAD_REQUEST,
+            Self::UserTerminated => StatusCode::BAD_GATEWAY,
+            Self::ConcurrencyError(_) => StatusCode::SERVICE_UNAVAILABLE,
+            Self::TooManyConcurrentRequests(_) => StatusCode::TOO_MANY_REQUESTS,
+            Self::CannotEmbedInput(_) => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
     }
 
     /// Get the variant name of the error.

--- a/crates/embedder-external/Cargo.toml
+++ b/crates/embedder-external/Cargo.toml
@@ -15,9 +15,9 @@ ndarray-serde = ["ndarray/serde"]
 [dependencies]
 axum = { version = "0.7.5", optional = true }
 clap = { version = "4.5.16", optional = true, features = ["derive"] }
-fastembed = { path = "../fastembed-rs" }
+fastembed = { version = "4.3.0" }
 # This needs to be the same version as in fastembed-rs
-ndarray = { version = "=0.15.0", default-features = false }
+ndarray = { version = "=0.16.0", default-features = false }
 serde = { version = "1.0.208" }
 serde_json = "1.0.125"
 utoipa = "4.2.3"

--- a/crates/embedder-lib/src/transform/models/custom.rs
+++ b/crates/embedder-lib/src/transform/models/custom.rs
@@ -27,17 +27,17 @@ impl Model {
         pooling: Option<fastembed::Pooling>,
         quantization: fastembed::QuantizationMode,
     ) -> Result<Arc<Self>, EmbedderError> {
-        let user_model = fastembed::UserDefinedEmbeddingModel {
+        let user_model = fastembed::UserDefinedEmbeddingModel::new(
             onnx_file,
-            tokenizer_files: fastembed::TokenizerFiles {
+            fastembed::TokenizerFiles {
                 tokenizer_file,
                 config_file,
                 special_tokens_map_file,
                 tokenizer_config_file,
             },
-            pooling: pooling.clone(),
-            quantization,
-        };
+        )
+        .with_pooling(pooling.clone().unwrap_or_default())
+        .with_quantization(quantization);
 
         fastembed::TextEmbedding::try_new_from_user_defined(user_model, Default::default())
             .map_err(|err| EmbedderError::ModelLoadError {

--- a/crates/embedder-lib/src/transform/models/sentence_transformers.rs
+++ b/crates/embedder-lib/src/transform/models/sentence_transformers.rs
@@ -51,9 +51,9 @@ macro_rules! create_model {
                 /// Create a new instance of the model.
                 pub fn new() -> Result<Arc<Self>, EmbedderError> {
                     match MODEL.get_or_init(|| {
-                        let user_model = fastembed::UserDefinedEmbeddingModel {
-                            onnx_file: binaries::$binaries::MODEL_FILE.to_vec(),
-                            tokenizer_files: fastembed::TokenizerFiles {
+                        let user_model = fastembed::UserDefinedEmbeddingModel::new(
+                            binaries::$binaries::MODEL_FILE.to_vec(),
+                            fastembed::TokenizerFiles {
                                 tokenizer_file: binaries::$binaries::TOKENIZER_FILE.to_vec(),
                                 config_file: binaries::$binaries::CONFIG_FILE.to_vec(),
                                 special_tokens_map_file:
@@ -61,9 +61,9 @@ macro_rules! create_model {
                                 tokenizer_config_file: binaries::$binaries::TOKENIZER_CONFIG_FILE
                                     .to_vec(),
                             },
-                            pooling: $pooling,
-                            quantization: $quantization,
-                        };
+                        )
+                        .with_pooling($pooling.unwrap_or_default())
+                        .with_quantization($quantization);
 
                         fastembed::TextEmbedding::try_new_from_user_defined(
                             user_model,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     image: denwong47/embedder-build
     volumes:
       - .:/root/crate/embedder
+      - ./target:/root/crate/embedder/target
     environment:
       - TARGET=x86_64-unknown-linux-gnu
       - BUILD_ARGS=--release --features=sentence_transformers,status
@@ -33,4 +34,4 @@ services:
         - BUILD_ARGS=--release --features=sentence_transformers,status
     image: denwong47/embedder-host
     ports:
-      - "3000:3000"
+      - "3456:3456"

--- a/docker/BuildFedora.Dockerfile
+++ b/docker/BuildFedora.Dockerfile
@@ -32,4 +32,4 @@ COPY --from=local-build /root/crate/embedder/target/${TARGET}/release/embedder /
 
 WORKDIR /root
 
-ENTRYPOINT [ "/root/embedder" ]
+ENTRYPOINT [ "/root/embedder", "--port", "3456" ]

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,8 +10,8 @@ pub struct CliArgs {
     #[arg(long, default_value_t = Ipv4Addr::new(0, 0, 0, 0))]
     host: Ipv4Addr,
 
-    /// The port to listen on. Defaults to 3000.
-    #[arg(short, long, default_value_t = 3000)]
+    /// The port to listen on. Defaults to 3456.
+    #[arg(short, long, default_value_t = 3456)]
     port: u16,
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,6 +2,17 @@ use embedder_external::{axum, serde::Serialize, serde_json};
 
 use embedder_err::EmbedderAPIError;
 
+use crate::helpers::ConcurrencyLimiter;
+use std::sync::OnceLock;
+
+/// The maximum number of concurrent requests.
+pub const MAX_CONCURRENT_REQUESTS: usize = 4;
+
+/// A [`ConcurrencyLimiter`] with a maximum of concurrent requests. Requests are required to acquire
+/// a token from the limiter before they can proceed.
+pub(crate) static CONCURRENT_LIMITER: OnceLock<ConcurrencyLimiter<MAX_CONCURRENT_REQUESTS>> =
+    OnceLock::new();
+
 /// A trait to convert a type to a JSON response.
 ///
 /// This trait is implemented for any type that implements `serde::Serialize`.

--- a/src/endpoints/embed.rs
+++ b/src/endpoints/embed.rs
@@ -8,10 +8,21 @@ use embedder_external::axum::{
 use embedder_external::serde::{Deserialize, Serialize};
 use embedder_external::{fastembed, ndarray, serde_json};
 use embedder_lib::{transform::CanTransform, Embedding};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, OnceLock,
+};
 use tokio::time::Instant;
 
-use crate::common::{calculate_default_batch_size, ToJsonResponse};
+use crate::{
+    common::{
+        calculate_default_batch_size, ToJsonResponse, CONCURRENT_LIMITER, MAX_CONCURRENT_REQUESTS,
+    },
+    helpers::ConcurrencyLimiter,
+};
+
+#[cfg(feature = "status")]
+use crate::status::Status;
 
 #[derive(Debug, Clone, Deserialize)]
 #[non_exhaustive]
@@ -100,6 +111,14 @@ pub async fn embed(
 ) -> Result<Json<serde_json::Value>, EmbedderAPIError> {
     let start = Instant::now();
 
+    #[cfg(feature = "status")]
+    Status::get().increment_requests();
+
+    let initiator = || {
+        eprintln!("Initializing the concurrent requests counter...");
+        ConcurrencyLimiter::<MAX_CONCURRENT_REQUESTS>::new()
+    };
+
     // Clone the model for logging only
     let model = request.model.clone();
     macro_rules! map_output_type_to_method {
@@ -107,6 +126,10 @@ pub async fn embed(
             match query.output {
                 $(
                     OutputType::$variant => {
+                        // Limit the number of concurrent requests by acquiring a token.
+                        // The token itself is not used, but upon dropping it, the lock is released.
+                        let _token = CONCURRENT_LIMITER.get_or_init(initiator).acquire()?;
+
                         let batch_size = request.batch_size.unwrap_or_else(|| calculate_default_batch_size(request.documents.len()));
                         let embeddings = tokio::task::spawn_blocking(move || {
                             eprintln!(
@@ -126,6 +149,7 @@ pub async fn embed(
                             }
                         )
                         .map_err(|err| EmbedderAPIError::ConcurrencyError(err.to_string()))??;
+
                         EmbedResponse {
                             model,
                             duration: start.elapsed().as_secs_f32(),

--- a/src/endpoints/health.rs
+++ b/src/endpoints/health.rs
@@ -1,0 +1,67 @@
+use embedder_external::{
+    axum::{self, response::IntoResponse, Json},
+    serde::{self, ser::SerializeStruct, Serialize},
+};
+
+use embedder_err::EmbedderAPIError;
+
+use crate::{
+    common::{CONCURRENT_LIMITER, MAX_CONCURRENT_REQUESTS},
+    helpers::ConcurrencyLimiter,
+};
+
+/// The response for the root endpoint.
+#[derive(Clone, Debug, Serialize)]
+pub struct HealthResponse {
+    max: usize,
+    current: usize,
+}
+
+impl HealthResponse {
+    /// Create a new instance of the root response.
+    pub fn new() -> Self {
+        let current = CONCURRENT_LIMITER
+            .get_or_init(ConcurrencyLimiter::<MAX_CONCURRENT_REQUESTS>::new)
+            .current();
+        Self {
+            max: MAX_CONCURRENT_REQUESTS,
+            current,
+        }
+    }
+
+    /// Get the status code for the response.
+    ///
+    /// If the number of concurrent requests is:
+    /// - greater than or equal to the maximum, the status code will be `503 Service Unavailable`.
+    /// - greater than or equal to half the maximum, the status code will be `429 Too Many Requests`.
+    /// - less than half the maximum, the status code will be `200 OK`.
+    pub fn status_code(&self) -> axum::http::StatusCode {
+        match self.current {
+            current if current >= self.max => axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            current if current >= self.max / 2 => axum::http::StatusCode::TOO_MANY_REQUESTS,
+            _ => axum::http::StatusCode::OK,
+        }
+    }
+}
+
+impl IntoResponse for HealthResponse {
+    fn into_response(self) -> axum::http::Response<axum::body::Body> {
+        (self.status_code(), Json(self).into_response()).into_response()
+    }
+}
+
+/// The health endpoint, for AWS Application Load Balancer health checks.
+///
+/// If the number of concurrent requests is:
+/// - greater than or equal to the maximum, the status code will be `503 Service Unavailable`.
+/// - greater than or equal to half the maximum, the status code will be `429 Too Many Requests`.
+/// - less than half the maximum, the status code will be `200 OK`.
+///
+/// This allows AWS to determine if the server is healthy or not, and route traffic
+/// accordingly.
+///
+/// The status code of this endpoint is not strictly following RESTful conventions; rather it was
+/// designed to be informative for AWS.
+pub async fn health() -> HealthResponse {
+    HealthResponse::new()
+}

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -6,3 +6,6 @@ pub use embed::*;
 
 mod root;
 pub use root::*;
+
+mod health;
+pub use health::*;

--- a/src/helpers/limiter.rs
+++ b/src/helpers/limiter.rs
@@ -1,0 +1,63 @@
+use embedder_err::EmbedderAPIError;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// A simple concurrency limiter that can be used to limit the number of concurrent requests.
+pub struct ConcurrencyLimiter<const L: usize> {
+    counter: AtomicUsize,
+}
+
+impl<const L: usize> ConcurrencyLimiter<L> {
+    /// Create a new concurrency limiter.
+    pub fn new() -> Self {
+        Self {
+            counter: AtomicUsize::new(0),
+        }
+    }
+
+    /// Get the current number of concurrent requests.
+    pub fn current(&self) -> usize {
+        self.counter.load(Ordering::SeqCst)
+    }
+
+    /// Attempt to acquire a concurrency token.
+    pub fn acquire(&self) -> Result<ConcurrencyToken<'_, L>, EmbedderAPIError> {
+        let previous_count = self.counter.fetch_add(1, Ordering::SeqCst);
+
+        if previous_count >= L {
+            self.release();
+            eprintln!(
+                "Too many concurrent requests ({}), rejecting request.",
+                previous_count
+            );
+            Err(EmbedderAPIError::TooManyConcurrentRequests(previous_count))
+        } else {
+            Ok(ConcurrencyToken::new(previous_count, self))
+        }
+    }
+
+    /// Decrement the counter.
+    fn release(&self) {
+        self.counter.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+/// A token that is issued for each request that successfully acquires the concurrency lock.
+pub struct ConcurrencyToken<'a, const L: usize> {
+    /// The ID of the token. This value is 0-indexed.
+    pub id: usize,
+    limiter: &'a ConcurrencyLimiter<L>,
+}
+
+impl<'a, const L: usize> ConcurrencyToken<'a, L> {
+    /// Create a new concurrency token.
+    pub fn new(id: usize, limiter: &'a ConcurrencyLimiter<L>) -> Self {
+        Self { id, limiter }
+    }
+}
+
+impl<const L: usize> Drop for ConcurrencyToken<'_, L> {
+    fn drop(&mut self) {
+        eprintln!("Concurrency token dropped, releasing lock #{}.", self.id);
+        self.limiter.release();
+    }
+}

--- a/src/helpers/mod.rs
+++ b/src/helpers/mod.rs
@@ -1,0 +1,5 @@
+//! This module contains helper functions and structs that are used in the main application.
+//!
+
+mod limiter;
+pub use limiter::ConcurrencyLimiter;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,8 @@ use args::CliArgs;
 
 mod common;
 
+pub(crate) mod helpers;
+
 mod endpoints;
 
 #[cfg(feature = "status")]
@@ -29,6 +31,7 @@ async fn main() -> Result<(), EmbedderAPIError> {
     // build our application with a single route
     let app = Router::new()
         .route("/", get(endpoints::root))
+        .route("/health", get(endpoints::health))
         .route("/embed", post(endpoints::embed));
 
     // run our app with hyper, listening globally on port 3000

--- a/src/status.rs
+++ b/src/status.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
 /// The global status of the server.
-static GLOBAL_STATUS: OnceLock<Arc<Status>> = OnceLock::new();
+pub(crate) static GLOBAL_STATUS: OnceLock<Arc<Status>> = OnceLock::new();
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
feat: `/health` endpoint that allows AWS ALB to determine the health of an endpoint.
chore: remove `fastembed` submodule and replace by `4.3.0`